### PR TITLE
add fcm for android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
        <meta-data android:name="com.google.android.geo.API_KEY"
            android:value="AIzaSyAbOGOC9O1lXpkgctocBG2fJz0ylDQA85g"/>
 
+       <meta-data
+           android:name="com.google.firebase.messaging.default_notification_channel_id"
+           android:value="flutter_sandbox_channel" />
+
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/lib/firebase_cloud_messaging/firebase_cloud_messaging_page.dart
+++ b/lib/firebase_cloud_messaging/firebase_cloud_messaging_page.dart
@@ -14,7 +14,6 @@ class FcmPage extends StatefulWidget {
 class _FcmPageState extends State<FcmPage> {
   FirebaseMessaging messaging = FirebaseMessaging.instance;
   NotificationSettings settings;
-  RemoteMessage initialMessage;
   String _token = "";
 
   Future<void> requestPermissions() async {
@@ -26,6 +25,7 @@ class _FcmPageState extends State<FcmPage> {
       provisional: false,
       sound: true,
     );
+    print('User granted permission: ${settings.authorizationStatus}');
   }
 
   Future<void> getToken() async {

--- a/lib/firebase_cloud_messaging/firebase_cloud_messaging_page.dart
+++ b/lib/firebase_cloud_messaging/firebase_cloud_messaging_page.dart
@@ -1,0 +1,75 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_sandbox/pageNavigatorCustom.dart';
+import 'package:provider/provider.dart';
+
+class FcmPage extends StatefulWidget {
+  const FcmPage({Key key}) : super(key: key);
+  static const id = "fcm_page";
+
+  @override
+  _FcmPageState createState() => _FcmPageState();
+}
+
+class _FcmPageState extends State<FcmPage> {
+  FirebaseMessaging messaging = FirebaseMessaging.instance;
+  NotificationSettings settings;
+  RemoteMessage initialMessage;
+  String _token = "";
+
+  Future<void> requestPermissions() async {
+    settings = await messaging.requestPermission(
+      alert: true,
+      announcement: false,
+      badge: true,
+      criticalAlert: false,
+      provisional: false,
+      sound: true,
+    );
+  }
+
+  Future<void> getToken() async {
+    String token = await messaging.getToken();
+    print(token);
+    setState(() {
+      _token = token;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    requestPermissions();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final PageNavigatorCustom _pageNavigator =
+        Provider.of<PageNavigatorCustom>(context);
+    _pageNavigator.setCurrentPageIndex = _pageNavigator.getPageIndex("FCM");
+    _pageNavigator.setFromIndex = _pageNavigator.getCurrentPageIndex;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Container(
+              color: Colors.grey.shade900,
+              child: Padding(
+                padding: const EdgeInsets.all(10.0),
+                child: Text(
+                  _token,
+                  style: TextStyle(color: Colors.white, fontSize: 20),
+                ),
+              )),
+        ),
+        ElevatedButton(
+          onPressed: () async {
+            await getToken();
+          },
+          child: Text("Get Token"),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_sandbox/basic_effects/basic_effects_page.dart';
 import 'package:flutter_sandbox/camera/camera_page.dart';
 import 'package:flutter_sandbox/firebase_auth/firebase_auth_login_page.dart';
 import 'package:flutter_sandbox/firebase_auth/firebase_auth_register_page.dart';
+import 'package:flutter_sandbox/firebase_cloud_messaging/firebase_cloud_messaging_page.dart';
 import 'package:flutter_sandbox/firebase_crashlytics/firebase_crashlytics_page.dart';
 import 'package:flutter_sandbox/firebase_firestore/firestore_page.dart';
 import 'package:flutter_sandbox/firebase_functions/firebase_functions_page.dart';
@@ -111,6 +112,9 @@ class _HomePageState extends State<HomePage> {
             _title = AppLocalizations.of(context).languagesTitle;
             break;
           case 12:
+            _title = AppLocalizations.of(context).fcmTitle;
+            break;
+          case 12:
             _title = AppLocalizations.of(context).loginTitle;
             break;
           case 13:
@@ -136,6 +140,7 @@ class _HomePageState extends State<HomePage> {
       RivePage(),
       SandboxLicensePage(),
       LanguagesPage(),
+      FcmPage(),
       // always add new screen above this comment so that auth remains the last two items.
       FirebaseAuthLoginPage(),
       FirebaseAuthRegistrationPage(),
@@ -374,6 +379,16 @@ class DrawerWindow extends StatelessWidget {
           if (_pageNavigator.getCurrentPageIndex != 11) {
             _pageController
                 .jumpToPage(_pageNavigator.getPageIndex('Languages'));
+          }
+          Navigator.pop(context);
+        },
+      ),
+      ListTile(
+        selected: _pageNavigator.getCurrentPageIndex == 12,
+        title: Text(AppLocalizations.of(context).fcmTitle),
+        onTap: () {
+          if (_pageNavigator.getCurrentPageIndex != 12) {
+            _pageController.jumpToPage(_pageNavigator.getPageIndex('FCM'));
           }
           Navigator.pop(context);
         },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -17,6 +17,7 @@
   "licenseTitle": "License",
   "accountTitle": "Account",
   "demosTitle": "Demos",
+  "fcmTitle": "FCM",
 
   "logOut": "Log out",
 
@@ -85,6 +86,5 @@
   "riveBouncing": "Bouncing",
   "riveWipers": "Wipers",
   "riveBroken": "Broken"
-
 
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -17,6 +17,7 @@
   "licenseTitle": "Licenza",
   "accountTitle": "Account",
   "demosTitle": "Demo",
+  "fcmTitle": "FCM",
 
   "logOut": "Disconnettersi",
 
@@ -85,6 +86,5 @@
   "riveBouncing": "Rimbalzare",
   "riveWipers": "Tergicristalli",
   "riveBroken": "Rotta"
-
 
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,9 +2,12 @@ import 'dart:async';
 
 import 'package:camera/camera.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_sandbox/auth.dart';
 import 'package:flutter_sandbox/basic_effects/basic_effects_page.dart';
 import 'package:flutter_sandbox/camera/camera_page.dart';
@@ -30,21 +33,143 @@ import 'home_page.dart';
 
 List<CameraDescription> cameraList;
 
+var flutterLocalNotificationsPlugin;
+
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+  print('Handling a background message ${message.data}');
+}
+
+const AndroidNotificationChannel channel = AndroidNotificationChannel(
+  'flutter_sandbox_channel', // id
+  'High Importance Notifications', // title
+  'This channel is used for important notifications.', // description
+  importance: Importance.max,
+);
+
+Function selectNotification;
+Function onDidReceiveLocalNotification;
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
   if (!kIsWeb) {
     cameraList = await availableCameras();
+    flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
+
+    await flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(channel);
   }
+  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+
+  await FirebaseMessaging.instance.setForegroundNotificationPresentationOptions(
+    alert: true, // Required to display a heads up notification
+    badge: true,
+    sound: true,
+  );
 
   runApp(MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   // This widget is the root of your application.
+
+  @override
+  _MyAppState createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final _pageController = PageController(initialPage: 0);
+
+  @override
+  void initState() {
+    super.initState();
+
+    selectNotification = (String payload) async {
+      _pageController.jumpToPage(12);
+    };
+
+    onDidReceiveLocalNotification =
+        (int id, String title, String body, String payload) async {
+      // display a dialog with the notification details, tap ok to go to another page
+      showDialog(
+        context: context,
+        builder: (BuildContext context) => CupertinoAlertDialog(
+          title: Text(title),
+          content: Text(body),
+          actions: [
+            CupertinoDialogAction(
+              isDefaultAction: true,
+              child: Text('Ok'),
+              onPressed: () async {
+                Navigator.of(context, rootNavigator: true).pop();
+                _pageController.jumpToPage(12);
+              },
+            )
+          ],
+        ),
+      );
+    };
+
+    if (!kIsWeb) {
+      const AndroidInitializationSettings initializationSettingsAndroid =
+          AndroidInitializationSettings('launch_background');
+      final IOSInitializationSettings initializationSettingsIOS =
+          IOSInitializationSettings(
+              onDidReceiveLocalNotification: onDidReceiveLocalNotification);
+      final InitializationSettings initializationSettings =
+          InitializationSettings(
+              android: initializationSettingsAndroid,
+              iOS: initializationSettingsIOS);
+
+      Future<void> initiateFlutterLocalNotificationPlugin() async {
+        await flutterLocalNotificationsPlugin.initialize(initializationSettings,
+            onSelectNotification: selectNotification);
+      }
+
+      initiateFlutterLocalNotificationPlugin();
+    }
+
+    FirebaseMessaging.instance
+        .getInitialMessage()
+        .then((RemoteMessage message) {
+      if (message != null) {
+        if (message.data["isDemo"] == "true") {
+          _pageController.jumpToPage(12); // update number to FCM page index
+        }
+      }
+    });
+
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+      RemoteNotification notification = message.notification;
+      AndroidNotification android = message.notification?.android;
+      if (notification != null && android != null) {
+        flutterLocalNotificationsPlugin.show(
+            notification.hashCode,
+            notification.title,
+            notification.body,
+            NotificationDetails(
+              android: AndroidNotificationDetails(
+                channel.id,
+                channel.name,
+                channel.description,
+                icon: 'launch_background',
+              ),
+            ));
+      }
+    });
+
+    FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
+      if (message.data["isDemo"] == "true") {
+        _pageController.jumpToPage(12); // update number to FCM page index
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    final _pageController = PageController(initialPage: 0);
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,7 +87,7 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
 
-    selectNotification = (String payload) async {
+    selectNotification = (String payload) {
       _pageController.jumpToPage(12);
     };
 

--- a/lib/pageNavigatorCustom.dart
+++ b/lib/pageNavigatorCustom.dart
@@ -17,8 +17,9 @@ class PageNavigatorCustom extends ChangeNotifier {
     "Rive": 9,
     "License": 10,
     "Languages": 11,
-    "FirebaseAuthLogin": 12,
-    "FirebaseAuthRegister": 13,
+    "FCM": 12,
+    "FirebaseAuthLogin": 13,
+    "FirebaseAuthRegister": 14,
   };
   int fromIndex;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -203,21 +203,21 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   firebase_crashlytics:
     dependency: "direct main"
     description:
@@ -232,11 +232,46 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "9.1.4"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.4"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.7"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.0+4"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -600,6 +635,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.19"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,8 @@ dependencies:
   parallax_image: ^0.3.1+1
   getwidget: ^1.2.4
   rive: ^0.7.3
+  firebase_messaging: ^9.1.4
+  flutter_local_notifications: ^5.0.0+4
 
 dev_dependencies:
   flutter_test:

--- a/web/index.html
+++ b/web/index.html
@@ -51,6 +51,8 @@
   <script src="https://www.gstatic.com/firebasejs/8.4.1/firebase-auth.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.4.1/firebase-firestore.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.4.1/firebase-functions.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/8.4.1/firebase-messaging.js"></script>
+
 
   <script>
   // Your web app's Firebase configuration

--- a/web/index.html
+++ b/web/index.html
@@ -51,7 +51,6 @@
   <script src="https://www.gstatic.com/firebasejs/8.4.1/firebase-auth.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.4.1/firebase-firestore.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.4.1/firebase-functions.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/8.4.1/firebase-messaging.js"></script>
 
 
   <script>


### PR DESCRIPTION
Added FCM notification for android. Web support is not added yet.
To see notifications through FCM, first, open the app and go to the FCM page. Press the get token button to see the unique token for the device. Copy the token and paste it into the cloud messaging of the Firebase console Send a test message to view the notification message in the device.